### PR TITLE
Avoiding node duplication update

### DIFF
--- a/DrawingPanel.cpp
+++ b/DrawingPanel.cpp
@@ -27,7 +27,7 @@ void DrawingPanel::OnLeftDClick(wxMouseEvent& evt)
 			wxT("Set the index of the node. Remember that \nthe node index is unique number."), 
 			wxT("Enter a number:"),
 			wxT("Set node index"), 
-			0, 
+			graph.MaxNodeIndex() + 1, 
 			std::numeric_limits<int>::min(),
 			std::numeric_limits<int>::max());
 

--- a/Graph.cpp
+++ b/Graph.cpp
@@ -161,8 +161,12 @@ bool Graph::Contain(int node_index)
 
 int Graph::MaxNodeIndex()
 {
-	Node* node = *(std::max_element(nodes.begin(), nodes.end()));
-	return node->index;
+	if (!nodes.empty())
+	{
+		Node* node = *(std::max_element(nodes.begin(), nodes.end()));
+		return node->index;
+	}
+	return -1; // the index of the first node will be 0
 }
 
 bool Graph::IsInsideNode(const wxPoint& pt)

--- a/Graph.cpp
+++ b/Graph.cpp
@@ -159,6 +159,12 @@ bool Graph::Contain(int node_index)
 
 }
 
+int Graph::MaxNodeIndex()
+{
+	Node* node = *(std::max_element(nodes.begin(), nodes.end()));
+	return node->index;
+}
+
 bool Graph::IsInsideNode(const wxPoint& pt)
 {
 	for (std::vector<Node*>::iterator iter = nodes.begin(); iter != nodes.end(); iter++)

--- a/Graph.h
+++ b/Graph.h
@@ -55,7 +55,7 @@ public:
 	size_t GetEdgeAmount();
 	void Clear(); // clears all the graph
 	bool Contain(int node_index); // searches for node with given index, if it exists return true
-
+	int MaxNodeIndex();
 
 	// for drawing
 	bool IsInsideNode(const wxPoint& pt);


### PR DESCRIPTION
The default node index has been changed. Now it is `max-node-index-in-the-graph + 1`. To do this, I also added the `MaxNodeIndex` method to the graph