### PR TITLE
Context menus

### DIFF
--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -55,7 +55,7 @@ void DrawingPanel::OnRightUp(wxMouseEvent &evt)
 		m_context_menu->Append(ID_ADD_EDGE, "Add edge");	
 	}
 
-	context_menu_click_coords = evt.GetPosition();
+	m_context_menu_click_coords = evt.GetPosition();
 	PopupMenu(m_context_menu, evt.GetPosition());
 }
 
@@ -204,7 +204,7 @@ void DrawingPanel::OnEditNode(wxCommandEvent &evt)
 		wxT("Edit the index of the node. Remember that \nthe node index is unique number."), 
 		wxT("Enter a number:"),
 		wxT("Set node index"), 
-		m_graph->GetNode(context_menu_click_coords)->index,
+		m_graph->GetNode(m_context_menu_click_coords)->index,
 		-9999,
 		99999);
 
@@ -217,7 +217,7 @@ void DrawingPanel::OnEditNode(wxCommandEvent &evt)
 		}
 		else 
 		{
-			m_graph->EditNode(context_menu_click_coords, dlg->GetValue());
+			m_graph->EditNode(m_context_menu_click_coords, dlg->GetValue());
 			Refresh();
 		}
 	}
@@ -225,7 +225,7 @@ void DrawingPanel::OnEditNode(wxCommandEvent &evt)
 
 void DrawingPanel::OnDeleteNode(wxCommandEvent &evt)
 {
-	m_graph->Erase(context_menu_click_coords);
+	m_graph->Erase(m_context_menu_click_coords);
 	Refresh();
 }
 
@@ -239,19 +239,21 @@ void DrawingPanel::OnEditEdge(wxCommandEvent &evt)
 		wxT("Edit the weight of the edge.  Remember that \nthe edge weight can be only integer."), 
 		wxT("Enter a number:"),
 		wxT("Set edge weight"), 
-		m_graph->GetEdge(context_menu_click_coords)->weight,
+		m_graph->GetEdge(m_context_menu_click_coords)->weight,
 		-9999,
 		99999);
 
 	if (dlg->ShowModal() == wxID_OK)
 	{
-		m_graph->GetEdge(context_menu_click_coords)->weight = dlg->GetValue();
+		m_graph->GetEdge(m_context_menu_click_coords)->weight = dlg->GetValue();
 		Refresh();
 	}
 }
 
 void DrawingPanel::OnTurnAroundEdge(wxCommandEvent &evt)
 {
+	m_graph->TurnAroundEdge(m_context_menu_click_coords);
+	Refresh();
 }
 
 void DrawingPanel::OnDeleteEdge(wxCommandEvent &evt)

--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -16,6 +16,7 @@ BEGIN_EVENT_TABLE(DrawingPanel, wxPanel)
 	EVT_LEFT_UP(DrawingPanel::OnLeftUp)
 	EVT_MOTION(DrawingPanel::OnMove)
 	EVT_MENU(ID_EDIT_NODE, DrawingPanel::OnEditNode)
+	EVT_MENU(ID_DELETE_NODE, DrawingPanel::OnDeleteNode)
 END_EVENT_TABLE()
 
 
@@ -218,6 +219,12 @@ void DrawingPanel::OnEditNode(wxCommandEvent &evt)
 			Refresh();
 		}
 	}
+}
+
+void DrawingPanel::OnDeleteNode(wxCommandEvent &evt)
+{
+	m_graph->Erase(context_menu_click_coords);
+	Refresh();
 }
 
 void DrawingPanel::OnClear()

--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -214,8 +214,7 @@ void DrawingPanel::OnEditNode(wxCommandEvent &evt)
 		}
 		else 
 		{
-			// add overloading EditNode to graph to change node params except coords
-			wxMessageBox("Success!");
+			m_graph->EditNode(context_menu_click_coords, dlg->GetValue());
 			Refresh();
 		}
 	}

--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -17,6 +17,9 @@ BEGIN_EVENT_TABLE(DrawingPanel, wxPanel)
 	EVT_MOTION(DrawingPanel::OnMove)
 	EVT_MENU(ID_EDIT_NODE, DrawingPanel::OnEditNode)
 	EVT_MENU(ID_DELETE_NODE, DrawingPanel::OnDeleteNode)
+	EVT_MENU(ID_EDIT_EDGE, DrawingPanel::OnEditEdge)
+	EVT_MENU(ID_TURN_AROUND_EDGE, DrawingPanel::OnTurnAroundEdge)
+	EVT_MENU(ID_DELETE_EDGE, DrawingPanel::OnDeleteEdge)
 END_EVENT_TABLE()
 
 
@@ -202,7 +205,6 @@ void DrawingPanel::OnEditNode(wxCommandEvent &evt)
 		wxT("Enter a number:"),
 		wxT("Set node index"), 
 		m_graph->GetNode(context_menu_click_coords)->index,
-		//m_graph->MaxNodeIndex() + 1, // todo: curr node index
 		-9999,
 		99999);
 
@@ -225,6 +227,35 @@ void DrawingPanel::OnDeleteNode(wxCommandEvent &evt)
 {
 	m_graph->Erase(context_menu_click_coords);
 	Refresh();
+}
+
+void DrawingPanel::OnEditEdge(wxCommandEvent &evt)
+{
+	// on windows it works normally with std::numeric_limits<int>
+	// but on linux, it doesn't render spin buttons
+	// if the max number is longer than 5 chars (inluding '-')
+	wxNumberEntryDialog* dlg = new wxNumberEntryDialog(
+		this,
+		wxT("Edit the weight of the edge.  Remember that \nthe edge weight can be only integer."), 
+		wxT("Enter a number:"),
+		wxT("Set edge weight"), 
+		m_graph->GetEdge(context_menu_click_coords)->weight,
+		-9999,
+		99999);
+
+	if (dlg->ShowModal() == wxID_OK)
+	{
+		m_graph->GetEdge(context_menu_click_coords)->weight = dlg->GetValue();
+		Refresh();
+	}
+}
+
+void DrawingPanel::OnTurnAroundEdge(wxCommandEvent &evt)
+{
+}
+
+void DrawingPanel::OnDeleteEdge(wxCommandEvent &evt)
+{
 }
 
 void DrawingPanel::OnClear()

--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -2,6 +2,7 @@
 
 BEGIN_EVENT_TABLE(DrawingPanel, wxPanel)
 	EVT_PAINT(DrawingPanel::OnPaint)
+	EVT_RIGHT_UP(DrawingPanel::OnRightUp)
 	EVT_LEFT_UP(DrawingPanel::OnLeftUp)
 	EVT_MOTION(DrawingPanel::OnMove)
 END_EVENT_TABLE()
@@ -14,7 +15,35 @@ DrawingPanel::DrawingPanel(wxWindow* parent, wxWindowID winid)
 	m_graph = new Graph();
 }
 
-void DrawingPanel::OnLeftUp(wxMouseEvent& evt)
+void DrawingPanel::OnRightUp(wxMouseEvent &evt)
+{
+	wxMenu* m_context_menu = nullptr;
+	m_context_menu = new wxMenu();
+
+	if(m_graph->IsInsideNode(evt.GetPosition()))
+	{
+		// node
+		m_context_menu->Append(wxID_ANY, "Edit node");
+		m_context_menu->Append(wxID_ANY, "Delete node");
+	}
+	else if (m_graph->IsOnEdge(evt.GetPosition()))
+	{
+		// edge
+		m_context_menu->Append(wxID_ANY, "Edit edge");
+		m_context_menu->Append(wxID_ANY, "Turn around");
+		m_context_menu->Append(wxID_ANY, "Delete node");
+	}
+	else
+	{
+		// empty area
+		m_context_menu->Append(wxID_ANY, "Add node");
+		m_context_menu->Append(wxID_ANY, "Add edge");	
+	}
+
+	PopupMenu(m_context_menu, evt.GetPosition());
+}
+
+void DrawingPanel::OnLeftUp(wxMouseEvent &evt)
 {
 	switch (m_drawing_regime)
 	{
@@ -143,8 +172,8 @@ void DrawingPanel::OnMove(wxMouseEvent& evt)
 	}
 	else if ((m_graph->IsOnEdge(evt.GetPosition()) || m_graph->IsInsideNode(evt.GetPosition())) && m_drawing_regime == DrawingPanel::DELETE_NODE_OR_EDGE)
 	{
-	// changing cursor in delete mode
-	SetCursor(wxCURSOR_HAND);
+		// changing cursor in delete mode
+		SetCursor(wxCURSOR_HAND);
 	}
 	else SetCursor(wxCURSOR_DEFAULT);
 }

--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -2,7 +2,7 @@
 
 BEGIN_EVENT_TABLE(DrawingPanel, wxPanel)
 	EVT_PAINT(DrawingPanel::OnPaint)
-	EVT_LEFT_DCLICK(DrawingPanel::OnLeftDClick)
+	EVT_LEFT_UP(DrawingPanel::OnLeftUp)
 	EVT_MOTION(DrawingPanel::OnMove)
 END_EVENT_TABLE()
 
@@ -14,7 +14,7 @@ DrawingPanel::DrawingPanel(wxWindow* parent, wxWindowID winid)
 	m_graph = new Graph();
 }
 
-void DrawingPanel::OnLeftDClick(wxMouseEvent& evt)
+void DrawingPanel::OnLeftUp(wxMouseEvent& evt)
 {
 	switch (m_drawing_regime)
 	{

--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -258,6 +258,8 @@ void DrawingPanel::OnTurnAroundEdge(wxCommandEvent &evt)
 
 void DrawingPanel::OnDeleteEdge(wxCommandEvent &evt)
 {
+	m_graph->Erase(m_context_menu_click_coords);
+	Refresh();
 }
 
 void DrawingPanel::OnClear()

--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -6,8 +6,7 @@ enum {
 	ID_EDIT_EDGE,
 	ID_TURN_AROUND_EDGE,
 	ID_DELETE_EDGE,
-	ID_ADD_NODE, 
-	ID_ADD_EDGE
+	ID_ADD_NODE,
 };
 
 BEGIN_EVENT_TABLE(DrawingPanel, wxPanel)
@@ -20,6 +19,7 @@ BEGIN_EVENT_TABLE(DrawingPanel, wxPanel)
 	EVT_MENU(ID_EDIT_EDGE, DrawingPanel::OnEditEdge)
 	EVT_MENU(ID_TURN_AROUND_EDGE, DrawingPanel::OnTurnAroundEdge)
 	EVT_MENU(ID_DELETE_EDGE, DrawingPanel::OnDeleteEdge)
+	EVT_MENU(ID_ADD_NODE, DrawingPanel::OnDeleteEdge)
 END_EVENT_TABLE()
 
 
@@ -28,6 +28,56 @@ DrawingPanel::DrawingPanel(wxWindow* parent, wxWindowID winid)
 {
 	SetDoubleBuffered(true);
 	m_graph = new Graph();
+}
+
+void DrawingPanel::AddNewNode(const wxPoint &node_coords)
+{
+	// on windows it works normally with std::numeric_limits<int>
+	// but on linux, it doesn't render spin buttons
+	// if the max number is longer than 5 chars (inluding '-')
+	wxNumberEntryDialog* dlg = new wxNumberEntryDialog(
+		this,
+		wxT("Set the index of the node. Remember that \nthe node index is unique number."), 
+		wxT("Enter a number:"),
+		wxT("Set node index"), 
+		m_graph->MaxNodeIndex() + 1, 
+		-9999,
+		99999);
+
+	if (dlg->ShowModal() == wxID_OK)
+	{
+		if (m_graph->Contain(dlg->GetValue()))
+		{
+			if(m_dupl_warning)wxLogWarning("You can't add node with index %i, because it is already exist.", dlg->GetValue());
+		}
+		else 
+		{
+			m_graph->AddNode(node_coords, dlg->GetValue());
+			Refresh();
+		}
+	}
+}
+
+void DrawingPanel::AddNewEdge(const Node* node_from, const Node* node_to)
+{
+	// on windows it works normally with std::numeric_limits<int>
+	// but on linux, it doesn't render spin buttons
+	// if the max number is longer than 5 chars (inluding '-')		
+	wxNumberEntryDialog* dlg = new wxNumberEntryDialog(
+	this,
+		wxT("Set the weight of the edge. Remember that \nthe edge weight can be only integer."),
+		wxT("Enter a number:"),
+		wxT("Set edge weight"),
+		0,
+		-9999,
+		99999);
+
+	if (dlg->ShowModal() == wxID_OK)
+	{
+		m_graph->AddEdge(node_from, node_to, dlg->GetValue());
+		m_selected_begin_node = nullptr;
+		Refresh();
+	}
 }
 
 void DrawingPanel::OnRightUp(wxMouseEvent &evt)
@@ -51,8 +101,7 @@ void DrawingPanel::OnRightUp(wxMouseEvent &evt)
 	else
 	{
 		// empty area
-		m_context_menu->Append(ID_ADD_NODE, "Add node");
-		m_context_menu->Append(ID_ADD_EDGE, "Add edge");	
+		m_context_menu->Append(ID_ADD_NODE, "Add node");	
 	}
 
 	m_context_menu_click_coords = evt.GetPosition();
@@ -68,30 +117,7 @@ void DrawingPanel::OnLeftUp(wxMouseEvent &evt)
 		break;
 	case DrawingPanel::ADD_NODE:
 	{
-		// on windows it works normally with std::numeric_limits<int>
-		// but on linux, it doesn't render spin buttons
-		// if the max number is longer than 5 chars (inluding '-')
-		wxNumberEntryDialog* dlg = new wxNumberEntryDialog(
-			this,
-			wxT("Set the index of the node. Remember that \nthe node index is unique number."), 
-			wxT("Enter a number:"),
-			wxT("Set node index"), 
-			m_graph->MaxNodeIndex() + 1, 
-			-9999,
-			99999);
-
-		if (dlg->ShowModal() == wxID_OK)
-		{
-			if (m_graph->Contain(dlg->GetValue()))
-			{
-				if(m_dupl_warning)wxLogWarning("You can't add node with index %i, because it is already exist.", dlg->GetValue());
-			}
-			else 
-			{
-				m_graph->AddNode(evt.GetPosition(), dlg->GetValue());
-				Refresh();
-			}
-		}
+		AddNewNode(evt.GetPosition());
 	}
 		break;
 	case DrawingPanel::ADD_EDGE:
@@ -107,24 +133,7 @@ void DrawingPanel::OnLeftUp(wxMouseEvent &evt)
 		{
 			if (m_graph->GetNode(evt.GetPosition()) != m_selected_begin_node)// preventing chosing the same node
 			{
-				// on windows it works normally with std::numeric_limits<int>
-				// but on linux, it doesn't render spin buttons
-				// if the max number is longer than 5 chars (inluding '-')				
-				wxNumberEntryDialog* dlg = new wxNumberEntryDialog(
-				this,
-					wxT("Set the weight of the edge. Remember that \nthe edge weight can be only integer."),
-					wxT("Enter a number:"),
-					wxT("Set edge weight"),
-					0,
-					-9999,
-					99999);
-
-				if (dlg->ShowModal() == wxID_OK)
-				{
-					m_graph->AddEdge(m_selected_begin_node, m_graph->GetNode(evt.GetPosition()), dlg->GetValue());
-					m_selected_begin_node = nullptr;
-					Refresh();
-				}
+				AddNewEdge(m_selected_begin_node, m_graph->GetNode(evt.GetPosition()));
 			}
 		}
 		break;

--- a/src/DrawingPanel.cpp
+++ b/src/DrawingPanel.cpp
@@ -6,7 +6,7 @@ enum {
 	ID_EDIT_EDGE,
 	ID_TURN_AROUND_EDGE,
 	ID_DELETE_EDGE,
-	ID_ADD_NODE,
+	ID_ADD_NEW_NODE,
 };
 
 BEGIN_EVENT_TABLE(DrawingPanel, wxPanel)
@@ -19,7 +19,7 @@ BEGIN_EVENT_TABLE(DrawingPanel, wxPanel)
 	EVT_MENU(ID_EDIT_EDGE, DrawingPanel::OnEditEdge)
 	EVT_MENU(ID_TURN_AROUND_EDGE, DrawingPanel::OnTurnAroundEdge)
 	EVT_MENU(ID_DELETE_EDGE, DrawingPanel::OnDeleteEdge)
-	EVT_MENU(ID_ADD_NODE, DrawingPanel::OnDeleteEdge)
+	EVT_MENU(ID_ADD_NEW_NODE, DrawingPanel::OnAddNewNode)
 END_EVENT_TABLE()
 
 
@@ -101,7 +101,7 @@ void DrawingPanel::OnRightUp(wxMouseEvent &evt)
 	else
 	{
 		// empty area
-		m_context_menu->Append(ID_ADD_NODE, "Add node");	
+		m_context_menu->Append(ID_ADD_NEW_NODE, "Add node");	
 	}
 
 	m_context_menu_click_coords = evt.GetPosition();
@@ -269,6 +269,11 @@ void DrawingPanel::OnDeleteEdge(wxCommandEvent &evt)
 {
 	m_graph->Erase(m_context_menu_click_coords);
 	Refresh();
+}
+
+void DrawingPanel::OnAddNewNode(wxCommandEvent &evt)
+{
+	AddNewNode(m_context_menu_click_coords);
 }
 
 void DrawingPanel::OnClear()

--- a/src/DrawingPanel.h
+++ b/src/DrawingPanel.h
@@ -50,6 +50,7 @@ public:
     
     // context menu buttons handlers
     void OnEditNode(wxCommandEvent& evt);
+    void OnDeleteNode(wxCommandEvent& evt);
 
     DECLARE_EVENT_TABLE();
 };

--- a/src/DrawingPanel.h
+++ b/src/DrawingPanel.h
@@ -38,7 +38,7 @@ public:
     bool m_dupl_warning = true;
 
     // temp variables
-    wxPoint context_menu_click_coords;
+    wxPoint m_context_menu_click_coords;
 
 
     void OnRightUp(wxMouseEvent& evt); // context menu

--- a/src/DrawingPanel.h
+++ b/src/DrawingPanel.h
@@ -40,6 +40,8 @@ public:
     // temp variables
     wxPoint m_context_menu_click_coords;
 
+    void AddNewNode(const wxPoint& node_coords);
+    void AddNewEdge(const Node* node_from, const Node* node_to);
 
     void OnRightUp(wxMouseEvent& evt); // context menu
     void OnLeftUp(wxMouseEvent& evt); // add/delete node or edge

--- a/src/DrawingPanel.h
+++ b/src/DrawingPanel.h
@@ -51,7 +51,10 @@ public:
     // context menu buttons handlers
     void OnEditNode(wxCommandEvent& evt);
     void OnDeleteNode(wxCommandEvent& evt);
-
+    void OnEditEdge(wxCommandEvent& evt);
+    void OnTurnAroundEdge(wxCommandEvent& evt);
+    void OnDeleteEdge(wxCommandEvent& evt);
+    
     DECLARE_EVENT_TABLE();
 };
 

--- a/src/DrawingPanel.h
+++ b/src/DrawingPanel.h
@@ -56,6 +56,7 @@ public:
     void OnEditEdge(wxCommandEvent& evt);
     void OnTurnAroundEdge(wxCommandEvent& evt);
     void OnDeleteEdge(wxCommandEvent& evt);
+    void OnAddNewNode(wxCommandEvent& evt);
     
     DECLARE_EVENT_TABLE();
 };

--- a/src/DrawingPanel.h
+++ b/src/DrawingPanel.h
@@ -26,16 +26,19 @@ public:
     void Print(wxDC& dc, int pageNum, wxSize dc_size);
     Graph* GetGraph();
     void SetGraph(Graph* graph_ptr);
-private:
+
+    private:
     Graph* m_graph;
     DrawingRegimes m_drawing_regime = STANDARD_CURSOR;
     Node* m_selected_begin_node = nullptr;
     ColourSchemes m_colour_scheme = ColourSchemes::COLOURED;
 
     // settings
-
     // show warning message if the user tries to add node with existing index
     bool m_dupl_warning = true;
+
+    // temp variables
+    wxPoint context_menu_click_coords;
 
 
     void OnRightUp(wxMouseEvent& evt); // context menu
@@ -45,7 +48,8 @@ private:
     void DrawEdge(const Edge* edge);
     void OnMove(wxMouseEvent& evt);
     
-    
+    // context menu buttons handlers
+    void OnEditNode(wxCommandEvent& evt);
 
     DECLARE_EVENT_TABLE();
 };

--- a/src/DrawingPanel.h
+++ b/src/DrawingPanel.h
@@ -38,8 +38,8 @@ private:
     bool m_dupl_warning = true;
 
 
-
-    void OnLeftDClick(wxMouseEvent& evt); // general drawing
+    
+    void OnLeftUp(wxMouseEvent& evt); // add/delete node or edge
     void OnPaint(wxPaintEvent& evt); // calls after Refresh()
     void DrawNode(const Node* node); // adds and draw a new node
     void DrawEdge(const Edge* edge);

--- a/src/DrawingPanel.h
+++ b/src/DrawingPanel.h
@@ -38,7 +38,7 @@ private:
     bool m_dupl_warning = true;
 
 
-    
+    void OnRightUp(wxMouseEvent& evt); // context menu
     void OnLeftUp(wxMouseEvent& evt); // add/delete node or edge
     void OnPaint(wxPaintEvent& evt); // calls after Refresh()
     void DrawNode(const Node* node); // adds and draw a new node

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -200,11 +200,6 @@ std::vector<Edge*> Graph::GetIncomingEdges(const Node* in)
 	return result;
 }
 
-void Graph::SetEdgeWeight(const Node* from, const Node* to, int weight)
-{
-
-}
-
 bool Graph::Empty()
 {
 	if (nodes.empty())

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -173,6 +173,15 @@ Edge* Graph::GetEdge(size_t index)
 	else throw "Index out of range";
 }
 
+Edge *Graph::GetEdge(const wxPoint &coords)
+{
+    for (std::vector<Edge*>::iterator iter = edges.begin(); iter != edges.end(); iter++)
+	{
+		if (IsEdge(coords, iter)) return (*iter);
+	}
+	return nullptr;
+}
+
 const Edge* Graph::GetEdge(size_t index) const
 {
 	if (edges.empty() || index >= edges.size()) return nullptr;

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -100,6 +100,18 @@ void Graph::Erase(const wxPoint& coords)
 	}
 }
 
+void Graph::TurnAroundEdge(const wxPoint &coords)
+{
+	for (std::vector<Edge*>::iterator iter = edges.begin(); iter != edges.end(); iter++)
+	{
+		if (IsEdge(coords, iter))
+		{
+			std::swap((*iter)->from, (*iter)->to);
+			return;
+		}
+	}
+}
+
 Node* Graph::GetNode(const wxPoint& node_coords)
 {
 	for (std::vector<Node*>::iterator iter = nodes.begin(); iter != nodes.end(); iter++)

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -24,6 +24,24 @@ void Graph::EditNode(const wxPoint& node_coords)
 	Rank();
 }
 
+void Graph::EditNode(const wxPoint &node_coords, int index, int early_event_deadline, int late_event_deadline, int time_reserve)
+{
+	Node* node = GetNode(node_coords);
+
+	node->index = index;
+
+	if(early_event_deadline != -1)
+		node->early_event_deadline = early_event_deadline;
+	
+	if(late_event_deadline != -1)
+		node->late_event_deadline = late_event_deadline;
+
+	if(time_reserve != -1)
+		node->time_reserve = time_reserve;
+
+
+}
+
 void Graph::AddEdge(const Node* from, const Node* to, int weight, bool critical_path)
 {
 	Edge* new_edge = new Edge;

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -57,7 +57,6 @@ public:
 	Edge* GetEdge(const wxPoint& coords);
 	const Edge* GetEdge(size_t index) const;
 	std::vector<Edge*> GetIncomingEdges(const Node* in);
-	void SetEdgeWeight(const Node* from, const Node* to, int weight);
 	
 	bool Empty();
 	void Rank(); // changes the order of the nodes in the array according to their idexes

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -50,10 +50,11 @@ public:
 
 	Node* GetNode(const wxPoint& node_coords);
 	Node* GetNode(size_t index);
-	Node* GetEdgeByNodeIndex(int index); // get node by its number (not index in vector)
 	const Node* GetNode(size_t index) const;
+	Node* GetEdgeByNodeIndex(int index); // get node by its number (not index in vector)
 	Edge* GetEdge(const Node* from, const Node* to);
 	Edge* GetEdge(size_t index);
+	Edge* GetEdge(const wxPoint& coords);
 	const Edge* GetEdge(size_t index) const;
 	std::vector<Edge*> GetIncomingEdges(const Node* in);
 	void SetEdgeWeight(const Node* from, const Node* to, int weight);

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -43,6 +43,7 @@ public:
 	//void AddNode(const wxPoint& coords, int index);
 	void AddNode(const wxPoint& coords, int index, int early_event_deadline = -1, int late_event_deadline = -1, int time_reserve = -1);
 	void EditNode(const wxPoint& node_coords);
+	void EditNode(const wxPoint& node_coords, int index, int early_event_deadline = -1, int late_event_deadline = -1, int time_reserve = -1);
 	void AddEdge(const Node* from, const Node* to, int weight = 0, bool critical_path = false);
 	void Erase(const wxPoint& coords); // erase node
 	Node* GetNode(const wxPoint& node_coords);

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -45,7 +45,9 @@ public:
 	void EditNode(const wxPoint& node_coords);
 	void EditNode(const wxPoint& node_coords, int index, int early_event_deadline = -1, int late_event_deadline = -1, int time_reserve = -1);
 	void AddEdge(const Node* from, const Node* to, int weight = 0, bool critical_path = false);
-	void Erase(const wxPoint& coords); // erase node
+	void Erase(const wxPoint& coords);
+	void TurnAroundEdge(const wxPoint& coords);
+
 	Node* GetNode(const wxPoint& node_coords);
 	Node* GetNode(size_t index);
 	Node* GetEdgeByNodeIndex(int index); // get node by its number (not index in vector)
@@ -55,6 +57,7 @@ public:
 	const Edge* GetEdge(size_t index) const;
 	std::vector<Edge*> GetIncomingEdges(const Node* in);
 	void SetEdgeWeight(const Node* from, const Node* to, int weight);
+	
 	bool Empty();
 	void Rank(); // changes the order of the nodes in the array according to their idexes
 


### PR DESCRIPTION
Added context menus for the following use cases:
1) Click on an empty drawing area. Show a context menu with one button to add a new node.
2) Click on an existing node, a context menu with two buttons will be displayed: "Change node index" and "Delete node".
3) Click on an existing node, a context menu with 3 buttons will be displayed: "Change edge weight", "Rotate edge" and "Delete edge".